### PR TITLE
Add patient status display screen function

### DIFF
--- a/surgical-app/src/app/patient/page.tsx
+++ b/surgical-app/src/app/patient/page.tsx
@@ -5,7 +5,6 @@ const StatusPage = () => {
   return (
     <div className="text-center pt-[120px] pb-[80px] flex flex-col items-center justify-center">
       <h1 className="text-3xl">PATIENT STATUS LIST</h1>
-      <p className="mt-2">Everyone can see this page</p>
       <div className="mt-4 flex flex-col items-center justify-center w-full px-4">
         <StatusTable />
       </div>

--- a/surgical-app/src/app/patient/status-update/page.tsx
+++ b/surgical-app/src/app/patient/status-update/page.tsx
@@ -99,13 +99,6 @@ export default function StatusUpdate() {
     }
   };
 
-  const handleCancel = () => {
-    // Just clear selection and messages (keep the loaded patient)
-    setNewStatus('');
-    setError('');
-    setSuccess('');
-  };
-
   const disableUpdate =
     !patient || !newStatus || (patient && newStatus === patient.status) || isUpdating;
 
@@ -212,12 +205,9 @@ export default function StatusUpdate() {
             </div>
 
             {/* Controls */}
-            <div className="flex justify-between pt-4">
-              <Button variant="secondary" onClick={handleCancel} disabled={isUpdating}>
-                Cancel
-              </Button>
+            <div className="flex justify-center pt-4">
               <Button onClick={handleUpdate} disabled={disableUpdate}>
-                {isUpdating ? 'Updating...' : 'Add / Update'}
+                {isUpdating ? 'Updating...' : 'Update'}
               </Button>
             </div>
           </>

--- a/surgical-app/src/app/patient/status-update/page.tsx
+++ b/surgical-app/src/app/patient/status-update/page.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -9,94 +12,216 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableRow } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 
+import type { Patient, PatientStatus } from '@/types/patient';
+import {
+  STATUS_LABELS,
+  getAllowedStatuses,
+  isValidPatientNumber,
+  normalizePatientNumber,
+} from '@/types/patient';
+import { getPatientById, updatePatientStatus } from '@/services/patientService';
+
 export default function StatusUpdate() {
+  // Basic form state
+  const [patientNumber, setPatientNumber] = useState('');
+  const [patient, setPatient] = useState<Patient | null>(null);
+
+  // Status dropdown state
+  const [allowed, setAllowed] = useState<PatientStatus[]>([]);
+  const [newStatus, setNewStatus] = useState<PatientStatus | ''>('');
+
+  // UI state
+  const [isSearching, setIsSearching] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<string>('');
+  const [success, setSuccess] = useState<string>('');
+
+  // Search by patient number
+  const handleSearch = async () => {
+    setError('');
+    setSuccess('');
+    setPatient(null);
+    setAllowed([]);
+    setNewStatus('');
+
+    const raw = patientNumber;
+    if (!isValidPatientNumber(raw)) {
+      setError('Patient number must be 6 letters/numbers (no spaces).');
+      return;
+    }
+
+    try {
+      setIsSearching(true);
+      const p = await getPatientById(raw);
+      if (!p) {
+        setError('No patient found for that number.');
+        return;
+      }
+      setPatient(p);
+      setAllowed(getAllowedStatuses(p.status));
+      // Normalize the input box for clarity
+      setPatientNumber(normalizePatientNumber(raw));
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('Failed to search. Please try again.');
+      }
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  // Update status (only to previous or next)
+  const handleUpdate = async () => {
+    if (!patient || !newStatus || newStatus === patient.status) return;
+
+    setError('');
+    setSuccess('');
+
+    try {
+      setIsUpdating(true);
+      await updatePatientStatus(patient.id, newStatus);
+      // Update local state so the UI reflects the change immediately
+      const updated: Patient = { ...patient, status: newStatus };
+      setPatient(updated);
+      setAllowed(getAllowedStatuses(updated.status));
+      setNewStatus('');
+      setSuccess('Status updated successfully.');
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('Failed to search. Please try again.');
+      }
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleCancel = () => {
+    // Just clear selection and messages (keep the loaded patient)
+    setNewStatus('');
+    setError('');
+    setSuccess('');
+  };
+
+  const disableUpdate =
+    !patient || !newStatus || (patient && newStatus === patient.status) || isUpdating;
+
   return (
     <section>
-      <div className="container mx-auto px-4 py-16">
+      <div className="container mx-auto px-4 py-16 max-w-2xl">
         <h1 className="font-bold text-2xl text-center mb-8 sm:text-3xl">Update Patient Status</h1>
 
-        <div className="space-y-6 max-w-sm mx-auto">
-          {/* Enter Patient Number to Search */}
-          <div className="flex items-center gap-2">
-            <label htmlFor="patient-number" className="whitespace-nowrap">
-              Patient Number:
-            </label>
-            <Input id="patient-number" className="max-w-xs" />
-            <Button variant="secondary">Search</Button>
-          </div>
-
-          {/* Display Patient Info Table After Search(Initially Hidden) */}
-          <div className="hidden">
-            <label htmlFor="patient-info" className="whitespace-nowrap">
-              Patient Info:
-            </label>
-            <Table className="mt-4">
-              <TableBody>
-                <TableRow>
-                  <TableHead className="w-48">First Name</TableHead>
-                  <TableCell>John</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableHead>Last Name</TableHead>
-                  <TableCell>Doe</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableHead>Address</TableHead>
-                  <TableCell>123 Alpha Drive</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableHead>City</TableHead>
-                  <TableCell>Los Angeles</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableHead>State</TableHead>
-                  <TableCell>California</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableHead>Phone Number</TableHead>
-                  <TableCell>123-456-7890</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-
-          {/* Show Current Status (Read-only) */}
-          <div className="flex items-center gap-2">
-            <label htmlFor="current-status" className="whitespace-nowrap">
-              Current Status:
-            </label>
-            <Input id="current-status" readOnly className="max-w-xs" />
-          </div>
-
-          {/* Select New Status (Only Next or Prior in Real Logic) */}
-          <div className="flex items-center gap-2">
-            <label htmlFor="new-status" className="whitespace-nowrap">
-              New Status:
-            </label>
-            <div className="w-full max-w-xs">
-              <Select>
-                <SelectTrigger id="new-status" className="w-full">
-                  <SelectValue placeholder="Select Status" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="checked-in">Checked In</SelectItem>
-                  <SelectItem value="pre-procedure">Pre-procedure</SelectItem>
-                  <SelectItem value="in-progress">In-progress</SelectItem>
-                  <SelectItem value="closing">Closing</SelectItem>
-                  <SelectItem value="recovery">Recovery</SelectItem>
-                  <SelectItem value="complete">Complete</SelectItem>
-                  <SelectItem value="dismissal">Dismissal</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {/* Control Buttons */}
-          <div className="flex justify-between pt-4">
-            <Button variant="secondary">Cancel</Button>
-            <Button>Add / Update</Button>
-          </div>
+        {/* Search row */}
+        <div className="flex items-center gap-2 mb-4">
+          <label htmlFor="patient-number" className="whitespace-nowrap">
+            Patient Number:
+          </label>
+          <Input
+            id="patient-number"
+            className="max-w-xs"
+            value={patientNumber}
+            onChange={(e) => setPatientNumber(e.target.value)}
+            placeholder="e.g. A1B2C3"
+            maxLength={6}
+          />
+          <Button variant="secondary" onClick={handleSearch} disabled={isSearching}>
+            {isSearching ? 'Searching...' : 'Search'}
+          </Button>
         </div>
+
+        {/* Messages */}
+        {error && <p className="text-sm text-red-600 mb-2">{error}</p>}
+        {success && <p className="text-sm text-green-600 mb-2">{success}</p>}
+
+        {/* Patient info table */}
+        {patient && (
+          <>
+            <div>
+              <label className="whitespace-nowrap font-medium">Patient Info:</label>
+              <Table className="mt-4">
+                <TableBody>
+                  <TableRow>
+                    <TableHead className="w-48">First Name</TableHead>
+                    <TableCell>{patient.first_name}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableHead>Last Name</TableHead>
+                    <TableCell>{patient.last_name}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableHead>Street Address</TableHead>
+                    <TableCell>{patient.street_address}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableHead>City</TableHead>
+                    <TableCell>{patient.city}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableHead>State</TableHead>
+                    <TableCell>{patient.state}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableHead>Country</TableHead>
+                    <TableCell>{patient.country}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableHead>Telephone</TableHead>
+                    <TableCell>{patient.telephone}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableCell>{patient.email}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Current status (read-only) */}
+            <div className="flex items-center gap-2 mt-6">
+              <label htmlFor="current-status" className="whitespace-nowrap">
+                Current Status:
+              </label>
+              <Input id="current-status" readOnly className="max-w-xs" value={patient.status} />
+            </div>
+
+            {/* New status (only allowed: previous or next) */}
+            <div className="flex items-center gap-2 mt-3">
+              <label htmlFor="new-status" className="whitespace-nowrap">
+                New Status:
+              </label>
+              <div className="w-full max-w-xs">
+                <Select
+                  value={newStatus || undefined}
+                  onValueChange={(v) => setNewStatus(v as PatientStatus)}
+                >
+                  <SelectTrigger id="new-status" className="w-full">
+                    <SelectValue placeholder="Select Status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {allowed.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {STATUS_LABELS[s]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {/* Controls */}
+            <div className="flex justify-between pt-4">
+              <Button variant="secondary" onClick={handleCancel} disabled={isUpdating}>
+                Cancel
+              </Button>
+              <Button onClick={handleUpdate} disabled={disableUpdate}>
+                {isUpdating ? 'Updating...' : 'Add / Update'}
+              </Button>
+            </div>
+          </>
+        )}
       </div>
     </section>
   );

--- a/surgical-app/src/components/StatusTable.tsx
+++ b/surgical-app/src/components/StatusTable.tsx
@@ -1,3 +1,10 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { getActivePatientsForBoard } from '@/services/patientService';
+import { PatientStatus, STATUS_COLORS } from '@/types/patient';
+
 import {
   Table,
   TableBody,
@@ -17,33 +24,136 @@ import {
   PaginationPrevious,
 } from '@/components/ui/pagination';
 
-// データの型定義
-type Status = 'Checked In' | 'In-progress' | 'Pre-Procedure';
-
-interface Record {
+/**
+ * Row type rendered in the table.
+ */
+type Row = {
   id: string;
-  status: Status;
+  status: PatientStatus;
   name: string;
-}
-
-// サンプルデータ
-const records: Record[] = [
-  { id: 'FIG123', status: 'Checked In', name: 'John Smith' },
-  { id: 'FIG123', status: 'In-progress', name: 'John Smith' },
-  { id: 'FIG123', status: 'Pre-Procedure', name: 'John Smith' },
-  { id: 'FIG123', status: 'Checked In', name: 'John Smith' },
-  { id: 'FIG123', status: 'In-progress', name: 'John Smith' },
-  { id: 'FIG123', status: 'Pre-Procedure', name: 'John Smith' },
-];
-
-// ステータスに応じたBadgeのスタイルを返すヘルパーオブジェクト
-const statusStyles: { [key in Status]: string } = {
-  'Checked In': 'bg-gray-800 text-white',
-  'In-progress': 'bg-gray-500 text-white',
-  'Pre-Procedure': 'bg-gray-200 text-gray-800',
 };
 
+/**
+ * Keeps UI structure intact while replacing logic with:
+ * - Loading active patients (status != "Dismissal")
+ * - Live updates via Supabase Realtime
+ * - Auto page rotation every 20 seconds
+ */
 export function StatusTable() {
+  // Table data
+  const [rows, setRows] = useState<Row[]>([]);
+
+  // Pagination state
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(6); // Small-screen default
+
+  /**
+   * Responsive page size:
+   * - sm and up: 10 rows
+   * - below sm: 6 rows
+   */
+  useEffect(() => {
+    const mql = window.matchMedia('(min-width: 640px)'); // Tailwind sm breakpoint
+    const apply = () => setPageSize(mql.matches ? 10 : 6);
+    apply();
+    mql.addEventListener?.('change', apply);
+    return () => mql.removeEventListener?.('change', apply);
+  }, []);
+
+  /**
+   * Initial load of active patients for the board.
+   * Assumes getActivePatientsForBoard() excludes "Dismissal".
+   */
+  useEffect(() => {
+    (async () => {
+      const data = await getActivePatientsForBoard();
+      setRows(data.map((d) => ({ id: d.id, status: d.status, name: d.name })));
+      setPage(0);
+    })().catch(console.error);
+  }, []);
+
+  /**
+   * Realtime subscription:
+   * Re-fetch whenever patients table changes (INSERT/UPDATE/DELETE).
+   * Make sure Realtime is enabled for "patients" in Supabase dashboard.
+   */
+  useEffect(() => {
+    const channel = supabase
+      .channel('public:patients')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'patients' }, async () => {
+        const data = await getActivePatientsForBoard();
+        setRows(data.map((d) => ({ id: d.id, status: d.status, name: d.name })));
+        setPage(0);
+      })
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [supabase]);
+
+  /**
+   * Derive current page slice and total pages.
+   */
+  const { totalPages, current } = useMemo(() => {
+    const total = Math.max(1, Math.ceil(rows.length / pageSize));
+    const start = page * pageSize;
+    const end = start + pageSize;
+    return { totalPages: total, current: rows.slice(start, end) };
+  }, [rows, page, pageSize]);
+
+  /**
+   * Auto-rotate pages every 20 seconds (as required).
+   */
+  const timerRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (timerRef.current) window.clearInterval(timerRef.current);
+    timerRef.current = window.setInterval(() => {
+      setPage((p) => {
+        const total = Math.max(1, Math.ceil(rows.length / pageSize));
+        return total <= 1 ? 0 : (p + 1) % total;
+      });
+    }, 20_000) as unknown as number;
+
+    return () => {
+      if (timerRef.current) window.clearInterval(timerRef.current);
+    };
+  }, [rows.length, pageSize]);
+
+  /**
+   * Pagination handlers compatible with the existing Pagination UI.
+   */
+  const goto = (n: number) => setPage(Math.min(Math.max(n, 0), totalPages - 1));
+  const onPrev = (e: React.MouseEvent) => {
+    e.preventDefault();
+    goto((page - 1 + totalPages) % totalPages);
+  };
+  const onNext = (e: React.MouseEvent) => {
+    e.preventDefault();
+    goto((page + 1) % totalPages);
+  };
+  const onPage = (n: number) => (e: React.MouseEvent) => {
+    e.preventDefault();
+    goto(n);
+  };
+
+  /**
+   * Badge style: use centralized STATUS_COLORS.
+   */
+  const badgeStyle = (status: PatientStatus) => ({
+    backgroundColor: STATUS_COLORS[status],
+    color: '#fff',
+  });
+
+  /**
+   * Simple page list:
+   * Show first 3 pages; if there are more, show an ellipsis and a jump to the last page.
+   * (Keeps original look-and-feel.)
+   */
+  const visiblePages = useMemo(() => {
+    return Array.from({ length: Math.min(3, totalPages) }, (_, i) => i);
+  }, [totalPages]);
+
   return (
     <div className="w-full pb-8 px-8">
       <div className="border rounded-lg max-w-[640px] mx-auto">
@@ -56,19 +166,27 @@ export function StatusTable() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {records.map((record, index) => (
-              <TableRow key={index}>
-                <TableCell className="font-medium text-left pl-4 text-xs sm:text-sm">
-                  {record.id}
+            {current.length === 0 ? (
+              <TableRow>
+                <TableCell className="pl-4 text-xs sm:text-sm" colSpan={3}>
+                  No active patients to display.
                 </TableCell>
-                <TableCell className="text-left">
-                  <Badge className={`${statusStyles[record.status]} text-xs px-2 py-1`}>
-                    {record.status}
-                  </Badge>
-                </TableCell>
-                <TableCell className="text-left text-xs sm:text-sm">{record.name}</TableCell>
               </TableRow>
-            ))}
+            ) : (
+              current.map((record) => (
+                <TableRow key={`${record.id}-${record.status}`}>
+                  <TableCell className="font-medium text-left pl-4 text-xs sm:text-sm">
+                    {record.id}
+                  </TableCell>
+                  <TableCell className="text-left">
+                    <Badge className="text-xs px-2 py-1" style={badgeStyle(record.status)}>
+                      {record.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-left text-xs sm:text-sm">{record.name}</TableCell>
+                </TableRow>
+              ))
+            )}
           </TableBody>
         </Table>
       </div>
@@ -77,28 +195,41 @@ export function StatusTable() {
         <Pagination>
           <PaginationContent className="flex-wrap">
             <PaginationItem>
-              <PaginationPrevious href="#" className="text-xs sm:text-sm" />
+              <PaginationPrevious href="#" className="text-xs sm:text-sm" onClick={onPrev} />
             </PaginationItem>
+
+            {visiblePages.map((n) => (
+              <PaginationItem key={n}>
+                <PaginationLink
+                  href="#"
+                  isActive={page === n}
+                  className="text-xs sm:text-sm"
+                  onClick={onPage(n)}
+                >
+                  {n + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+
+            {totalPages > 3 && (
+              <>
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink
+                    href="#"
+                    className="text-xs sm:text-sm"
+                    onClick={onPage(totalPages - 1)}
+                  >
+                    {totalPages}
+                  </PaginationLink>
+                </PaginationItem>
+              </>
+            )}
+
             <PaginationItem>
-              <PaginationLink href="#" isActive className="text-xs sm:text-sm">
-                1
-              </PaginationLink>
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationLink href="#" className="text-xs sm:text-sm">
-                2
-              </PaginationLink>
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationLink href="#" className="text-xs sm:text-sm">
-                3
-              </PaginationLink>
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationEllipsis />
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationNext href="#" className="text-xs sm:text-sm" />
+              <PaginationNext href="#" className="text-xs sm:text-sm" onClick={onNext} />
             </PaginationItem>
           </PaginationContent>
         </Pagination>

--- a/surgical-app/src/services/patientService.ts
+++ b/surgical-app/src/services/patientService.ts
@@ -1,39 +1,206 @@
-// Client-side service: call Supabase directly from the browser.
-// IMPORTANT: Make sure RLS/Policies enforce who can read/update.
-// Adjust import path to your Supabase client.
+// src/services/patientService.ts
 import { supabase } from '@/lib/supabase';
-import type { Patient, PatientStatus } from '@/types/patient';
-import { getAllowedStatuses, normalizePatientNumber } from '@/types/patient';
+import {
+  Patient,
+  PatientCreate,
+  PatientStatus,
+  PatientUpdate,
+  STATUS_ORDER,
+} from '@/types/patient';
 
-const TABLE = 'patients';
+// -------------------- Utilities --------------------
 
-// Fetch a patient by patient number (id).
-export async function getPatientById(id: string): Promise<Patient | null> {
-  const normalized = normalizePatientNumber(id);
-  const { data, error } = await supabase
-    .from(TABLE)
-    .select(
-      'id, first_name, last_name, street_address, city, state, country, telephone, email, status'
-    )
-    .eq('id', normalized)
-    .maybeSingle();
+// Characters allowed in a generated patient id (patient number).
+// The spec requires "exactly six characters containing any combination of letters or numbers".
+const ALNUM = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
-  if (error) throw new Error(error.message);
-  return (data as Patient) ?? null;
+// Generates a random 6-character alphanumeric id.
+// This satisfies the format requirement but not uniqueness or PII(=Personally Identifiable Information) checks by itself.
+function randomId6() {
+  let s = '';
+  for (let i = 0; i < 6; i++) s += ALNUM[Math.floor(Math.random() * ALNUM.length)];
+  return s;
 }
 
-// Update status with strict validation (only previous or next allowed).
-export async function updatePatientStatus(id: string, nextStatus: PatientStatus): Promise<void> {
-  const patient = await getPatientById(id);
-  if (!patient) throw new Error('No patient found for that number.');
+// Checks whether a given patient id already exists in the database.
+async function isPatientIdTaken(id: string) {
+  const { data, error } = await supabase.from('patients').select('id').eq('id', id).limit(1);
+  if (error) throw error;
+  return (data?.length || 0) > 0;
+}
 
-  const allowed = getAllowedStatuses(patient.status);
-  if (!allowed.includes(nextStatus)) {
-    // Enforce the spec: can only move to the previous or next status.
-    throw new Error('Only the previous or the next status is allowed.');
+// Builds a set of "PII tokens" (2~6 char substrings) from fields like name, address,
+// and the local part of email. We use these tokens to ensure the generated id does not
+// include any part of a patient's personal information.
+function buildPiiTokens(input: PatientCreate) {
+  const toks: string[] = [];
+  const push = (s?: string) => {
+    const v = (s ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    for (let len = 2; len <= Math.min(6, v.length); len++) {
+      for (let i = 0; i + len <= v.length; i++) toks.push(v.slice(i, i + len));
+    }
+  };
+  push(input.first_name);
+  push(input.last_name);
+  push(input.street_address);
+  push(input.city);
+  push(input.state);
+  push(input.country);
+  push(input.telephone);
+  push((input.email || '').split('@')[0]);
+  return new Set(toks);
+}
+
+// Generates a patient id that is:
+// 1) correct format (6 alphanumeric chars),
+// 2) not containing any substring of personally identifiable information, and
+// 3) unique in the database.
+// Retries up to N times to find a safe and unique id.
+async function generateSafePatientId(input: PatientCreate) {
+  const pii = buildPiiTokens(input);
+  for (let i = 0; i < 50; i++) {
+    const id = randomId6();
+    const low = id.toLowerCase();
+
+    // Reject ids that contain any 2+ char PII token.
+    let containsPII = false;
+    for (const t of pii) {
+      if (t.length >= 2 && low.includes(t)) {
+        containsPII = true;
+        break;
+      }
+    }
+    if (containsPII) continue;
+
+    // Reject ids already taken in the DB.
+    if (await isPatientIdTaken(id)) continue;
+
+    return id;
   }
+  throw new Error('Failed to generate a safe unique patient number');
+}
 
-  const { error } = await supabase.from(TABLE).update({ status: nextStatus }).eq('id', patient.id); // use normalized id returned from DB
+// Validates that the next status is either the immediate previous or immediate next
+// status in STATUS_ORDER. Skipping steps is not allowed. Reversing is allowed only
+// to the prior status.
+function assertNeighborTransition(current: PatientStatus, next: PatientStatus) {
+  const i = STATUS_ORDER.indexOf(current);
+  const j = STATUS_ORDER.indexOf(next);
+  if (i === -1 || j === -1) throw new Error('Invalid status');
 
-  if (error) throw new Error(error.message);
+  // Only allow moving to indices i-1 or i+1, if they exist within bounds.
+  const allowed = [i - 1, i + 1].filter((k) => k >= 0 && k < STATUS_ORDER.length);
+  if (!allowed.includes(j)) {
+    throw new Error(
+      'Statuses may not be skipped. You can only move to the immediate prior or next status.'
+    );
+  }
+}
+
+// -------------------- CRUD --------------------
+
+// Creates a new patient record from form input.
+// - Generates a safe 6-char id that avoids PII and collisions.
+// - Sets the initial status to "Checked In" per the spec.
+// - Returns the full inserted record.
+export async function createPatient(input: PatientCreate) {
+  const id = await generateSafePatientId(input);
+  const status: PatientStatus = 'Checked In';
+
+  const payload = { ...input, id, status };
+  const { data, error } = await supabase.from('patients').insert([payload]).select().single();
+
+  if (error) throw error;
+  return data as Patient;
+}
+
+// Updates personal/contact info for an existing patient.
+// - Use this to edit fields like address, phone, email, etc.
+// - id and status are intentionally NOT updatable here.
+export async function updatePatient(patientId: string, updates: PatientUpdate) {
+  const safe: Record<string, unknown> = { ...updates };
+  // Using `any` here avoids TypeScript complaints about removing keys
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  delete (safe as any).id;
+  delete (safe as any).status;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  const { data, error } = await supabase
+    .from('patients')
+    .update(safe)
+    .eq('id', patientId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Patient;
+}
+
+// Updates a patient's status with strict sequencing rules:
+// - You may move only to the immediate prior or next status.
+// - Skipping statuses is not allowed.
+// - Reversing is allowed only one step back.
+export async function updatePatientStatus(patientId: string, next: PatientStatus) {
+  // Read the current status to validate the requested transition.
+  const { data: currentList, error: readErr } = await supabase
+    .from('patients')
+    .select('id, status')
+    .eq('id', patientId)
+    .limit(1);
+
+  if (readErr) throw readErr;
+  const current = currentList?.[0];
+  if (!current) throw new Error('Patient not found');
+
+  assertNeighborTransition(current.status as PatientStatus, next);
+
+  const { data, error } = await supabase
+    .from('patients')
+    .update({ status: next })
+    .eq('id', patientId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Patient;
+}
+
+// Returns the minimal dataset for the public status board.
+// - Excludes "Dismissal" because those patients should be removed from the display.
+// - Orders by creation time so the board cycles in a stable order.
+export async function getActivePatientsForDisplay() {
+  const { data, error } = await supabase
+    .from('patients')
+    .select('id, status')
+    .neq('status', 'Dismissal')
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  return data as Pick<Patient, 'id' | 'status'>[];
+}
+
+// OPTIONAL: Returns full patient rows ordered by creation time (newest first).
+// - Useful for admin dashboards, debugging, or when showing a full list before filtering/search.
+// - Not required for the public status display MVP.
+export async function getPatients() {
+  const { data, error } = await supabase
+    .from('patients')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  return data as Patient[];
+}
+
+// OPTIONAL: Searches patients by last name for admin/status-update screens.
+// - Uses case-insensitive match and sorts by last name.
+export async function searchPatientsByLastName(lastName: string) {
+  const { data, error } = await supabase
+    .from('patients')
+    .select('*')
+    .ilike('last_name', `%${lastName}%`)
+    .order('last_name', { ascending: true });
+
+  if (error) throw error;
+  return data as Patient[];
 }

--- a/surgical-app/src/services/patientService.ts
+++ b/surgical-app/src/services/patientService.ts
@@ -1,206 +1,39 @@
-// src/services/patientService.ts
+// Client-side service: call Supabase directly from the browser.
+// IMPORTANT: Make sure RLS/Policies enforce who can read/update.
+// Adjust import path to your Supabase client.
 import { supabase } from '@/lib/supabase';
-import {
-  Patient,
-  PatientCreate,
-  PatientStatus,
-  PatientUpdate,
-  STATUS_ORDER,
-} from '@/types/patient';
+import type { Patient, PatientStatus } from '@/types/patient';
+import { getAllowedStatuses, normalizePatientNumber } from '@/types/patient';
 
-// -------------------- Utilities --------------------
+const TABLE = 'patients';
 
-// Characters allowed in a generated patient id (patient number).
-// The spec requires "exactly six characters containing any combination of letters or numbers".
-const ALNUM = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+// Fetch a patient by patient number (id).
+export async function getPatientById(id: string): Promise<Patient | null> {
+  const normalized = normalizePatientNumber(id);
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select(
+      'id, first_name, last_name, street_address, city, state, country, telephone, email, status'
+    )
+    .eq('id', normalized)
+    .maybeSingle();
 
-// Generates a random 6-character alphanumeric id.
-// This satisfies the format requirement but not uniqueness or PII(=Personally Identifiable Information) checks by itself.
-function randomId6() {
-  let s = '';
-  for (let i = 0; i < 6; i++) s += ALNUM[Math.floor(Math.random() * ALNUM.length)];
-  return s;
+  if (error) throw new Error(error.message);
+  return (data as Patient) ?? null;
 }
 
-// Checks whether a given patient id already exists in the database.
-async function isPatientIdTaken(id: string) {
-  const { data, error } = await supabase.from('patients').select('id').eq('id', id).limit(1);
-  if (error) throw error;
-  return (data?.length || 0) > 0;
-}
+// Update status with strict validation (only previous or next allowed).
+export async function updatePatientStatus(id: string, nextStatus: PatientStatus): Promise<void> {
+  const patient = await getPatientById(id);
+  if (!patient) throw new Error('No patient found for that number.');
 
-// Builds a set of "PII tokens" (2~6 char substrings) from fields like name, address,
-// and the local part of email. We use these tokens to ensure the generated id does not
-// include any part of a patient's personal information.
-function buildPiiTokens(input: PatientCreate) {
-  const toks: string[] = [];
-  const push = (s?: string) => {
-    const v = (s ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
-    for (let len = 2; len <= Math.min(6, v.length); len++) {
-      for (let i = 0; i + len <= v.length; i++) toks.push(v.slice(i, i + len));
-    }
-  };
-  push(input.first_name);
-  push(input.last_name);
-  push(input.street_address);
-  push(input.city);
-  push(input.state);
-  push(input.country);
-  push(input.telephone);
-  push((input.email || '').split('@')[0]);
-  return new Set(toks);
-}
-
-// Generates a patient id that is:
-// 1) correct format (6 alphanumeric chars),
-// 2) not containing any substring of personally identifiable information, and
-// 3) unique in the database.
-// Retries up to N times to find a safe and unique id.
-async function generateSafePatientId(input: PatientCreate) {
-  const pii = buildPiiTokens(input);
-  for (let i = 0; i < 50; i++) {
-    const id = randomId6();
-    const low = id.toLowerCase();
-
-    // Reject ids that contain any 2+ char PII token.
-    let containsPII = false;
-    for (const t of pii) {
-      if (t.length >= 2 && low.includes(t)) {
-        containsPII = true;
-        break;
-      }
-    }
-    if (containsPII) continue;
-
-    // Reject ids already taken in the DB.
-    if (await isPatientIdTaken(id)) continue;
-
-    return id;
+  const allowed = getAllowedStatuses(patient.status);
+  if (!allowed.includes(nextStatus)) {
+    // Enforce the spec: can only move to the previous or next status.
+    throw new Error('Only the previous or the next status is allowed.');
   }
-  throw new Error('Failed to generate a safe unique patient number');
-}
 
-// Validates that the next status is either the immediate previous or immediate next
-// status in STATUS_ORDER. Skipping steps is not allowed. Reversing is allowed only
-// to the prior status.
-function assertNeighborTransition(current: PatientStatus, next: PatientStatus) {
-  const i = STATUS_ORDER.indexOf(current);
-  const j = STATUS_ORDER.indexOf(next);
-  if (i === -1 || j === -1) throw new Error('Invalid status');
+  const { error } = await supabase.from(TABLE).update({ status: nextStatus }).eq('id', patient.id); // use normalized id returned from DB
 
-  // Only allow moving to indices i-1 or i+1, if they exist within bounds.
-  const allowed = [i - 1, i + 1].filter((k) => k >= 0 && k < STATUS_ORDER.length);
-  if (!allowed.includes(j)) {
-    throw new Error(
-      'Statuses may not be skipped. You can only move to the immediate prior or next status.'
-    );
-  }
-}
-
-// -------------------- CRUD --------------------
-
-// Creates a new patient record from form input.
-// - Generates a safe 6-char id that avoids PII and collisions.
-// - Sets the initial status to "Checked In" per the spec.
-// - Returns the full inserted record.
-export async function createPatient(input: PatientCreate) {
-  const id = await generateSafePatientId(input);
-  const status: PatientStatus = 'Checked In';
-
-  const payload = { ...input, id, status };
-  const { data, error } = await supabase.from('patients').insert([payload]).select().single();
-
-  if (error) throw error;
-  return data as Patient;
-}
-
-// Updates personal/contact info for an existing patient.
-// - Use this to edit fields like address, phone, email, etc.
-// - id and status are intentionally NOT updatable here.
-export async function updatePatient(patientId: string, updates: PatientUpdate) {
-  const safe: Record<string, unknown> = { ...updates };
-  // Using `any` here avoids TypeScript complaints about removing keys
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  delete (safe as any).id;
-  delete (safe as any).status;
-  /* eslint-enable @typescript-eslint/no-explicit-any */
-
-  const { data, error } = await supabase
-    .from('patients')
-    .update(safe)
-    .eq('id', patientId)
-    .select()
-    .single();
-
-  if (error) throw error;
-  return data as Patient;
-}
-
-// Updates a patient's status with strict sequencing rules:
-// - You may move only to the immediate prior or next status.
-// - Skipping statuses is not allowed.
-// - Reversing is allowed only one step back.
-export async function updatePatientStatus(patientId: string, next: PatientStatus) {
-  // Read the current status to validate the requested transition.
-  const { data: currentList, error: readErr } = await supabase
-    .from('patients')
-    .select('id, status')
-    .eq('id', patientId)
-    .limit(1);
-
-  if (readErr) throw readErr;
-  const current = currentList?.[0];
-  if (!current) throw new Error('Patient not found');
-
-  assertNeighborTransition(current.status as PatientStatus, next);
-
-  const { data, error } = await supabase
-    .from('patients')
-    .update({ status: next })
-    .eq('id', patientId)
-    .select()
-    .single();
-
-  if (error) throw error;
-  return data as Patient;
-}
-
-// Returns the minimal dataset for the public status board.
-// - Excludes "Dismissal" because those patients should be removed from the display.
-// - Orders by creation time so the board cycles in a stable order.
-export async function getActivePatientsForDisplay() {
-  const { data, error } = await supabase
-    .from('patients')
-    .select('id, status')
-    .neq('status', 'Dismissal')
-    .order('created_at', { ascending: true });
-
-  if (error) throw error;
-  return data as Pick<Patient, 'id' | 'status'>[];
-}
-
-// OPTIONAL: Returns full patient rows ordered by creation time (newest first).
-// - Useful for admin dashboards, debugging, or when showing a full list before filtering/search.
-// - Not required for the public status display MVP.
-export async function getPatients() {
-  const { data, error } = await supabase
-    .from('patients')
-    .select('*')
-    .order('created_at', { ascending: false });
-
-  if (error) throw error;
-  return data as Patient[];
-}
-
-// OPTIONAL: Searches patients by last name for admin/status-update screens.
-// - Uses case-insensitive match and sorts by last name.
-export async function searchPatientsByLastName(lastName: string) {
-  const { data, error } = await supabase
-    .from('patients')
-    .select('*')
-    .ilike('last_name', `%${lastName}%`)
-    .order('last_name', { ascending: true });
-
-  if (error) throw error;
-  return data as Patient[];
+  if (error) throw new Error(error.message);
 }

--- a/surgical-app/src/types/patient.ts
+++ b/surgical-app/src/types/patient.ts
@@ -30,6 +30,17 @@ export const STATUS_LABELS: Record<PatientStatus, string> = {
   Dismissal: 'Dismissal',
 };
 
+// Assign unique colors to each status.
+export const STATUS_COLORS: Record<PatientStatus, string> = {
+  'Checked In': '#1E90FF', // Dodger Blue
+  'Pre-Procedure': '#FFA500', // Orange
+  'In-Progress': '#FF4500', // OrangeRed
+  Closing: '#8A2BE2', // BlueViolet
+  Recovery: '#32CD32', // LimeGreen
+  Complete: '#2E8B57', // SeaGreen
+  Dismissal: '#696969', // DimGray
+};
+
 // Personal/contact fields collected on the Patient Information form.
 export interface PatientBase {
   first_name: string;


### PR DESCRIPTION
<img width="1552" height="987" alt="Screenshot 2025-08-15 at 6 14 20 PM" src="https://github.com/user-attachments/assets/4b8aa4db-87eb-4424-b23e-2e359e6fc99c" />

## Summary
Implements the color-coded Status and Patient Status Board function. Board shows patient number + current status as per database, updates live (or via Refresh), and auto-rotates pages every 20s.

## What was done

- Added STATUS_COLORS and reused centralized STATUS_ORDER/labels/neighbor rules.

- Loads only active patients (excludes Dismissal), ordered by created_at.

- Realtime subscription to reflect backend changes

- Auto pagination with 20s page rotation; existing Table/Pagination UI preserved.

## Request for Review

- Verify board shows only id + status; Dismissal rows do not appear.

- Update any patient’s status in backend → board reflects change

- Add enough patients to exceed one page → auto-rotate every 20s.